### PR TITLE
chore: upgrade CI to Node 20 and actions to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+        uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: "16"
+          node-version: "20"
           cache: "yarn"
       - name: Install
         run: yarn --immutable


### PR DESCRIPTION
Node 16 reached end-of-life in September 2023. Bumps GitHub Actions runners to Node 20 LTS and updates actions/checkout and actions/setup-node to v4.