### PR TITLE
fix: restore subdued neutral Button variant (v1.1.2)

### DIFF
--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -128,12 +128,10 @@ export const Button = styled("button", {
           },
       },
       neutral: {
-        bc: "$primary",
-        color: "$neutral1",
-        "&:hover": {
-          bc: "$neutral5",
-          color: "$primary",
-        },
+        border: "1px solid $neutral7",
+        bc: "$neutral4",
+        color: "$neutral12",
+        "&:hover": { bc: "$neutral5" },
         "&:active": { bc: "$neutral6" },
         "&:disabled": {
           opacity: 0.5,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livepeer/design-system",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/index.es.js",


### PR DESCRIPTION
## Summary

Restores the `neutral` Button variant to its pre-#136 definition (grey-bordered, subdued) and bumps the package version to `1.1.2`.

## Why

PR #136 (merged 2024-04-18, shipped in v1.1.1) changed the default `neutral` Button variant from a subdued grey-bordered style to a solid high-contrast fill using the newly introduced `\$primary` semantic token (black/white). Since `neutral` is the default variant, every consumer \`<Button>\` without an explicit \`variant\` prop silently changed appearance between 1.1.0 and 1.1.1.

The Livepeer Explorer is pinned to \`1.1.0\` and relies on this subdued style for its default-variant buttons (Create Poll, Vote, toolbar buttons, etc.). We want to preserve this visual design heading into the v2.0 Tailwind + CVA migration, where Button variants will be re-architected around shadcn conventions (\`default\` / \`outline\` / \`secondary\` / \`ghost\` / \`destructive\`).

## What changed

- **components/Button.tsx**: \`neutral\` variant reverted to \`border: 1px solid \$neutral7\`, \`bc: \$neutral4\`, \`color: \$neutral12\` (hover: \`\$neutral5\`). Matches the pre-#136 behavior exactly.
- **package.json**: version bumped from \`1.1.0\` → \`1.1.2\`.

## What's NOT changed

- The new \`\$primary\` and \`\$background\` semantic tokens added in #136 remain in \`stitches.config.ts\`. Only the Button variant change is reverted.
- No other variants (primary, ghost, color variants, compound variants) are touched.

## Consumer migration

After this is merged and published to npm as \`1.1.2\`, Explorer should bump its \`@livepeer/design-system\` pin from \`1.1.0\` → \`1.1.2\`. No code changes needed in Explorer — the default-variant buttons will render identically to today.

## Test plan

- [ ] Run the docs site locally (\`yarn dev\`) and verify neutral Button renders with the grey border + \`\$neutral4\` background
- [ ] yalc-link v1.1.2 into Explorer and confirm Create Poll / Vote / toolbar buttons match current production visual
- [ ] Verify no unintended changes to primary, ghost, or color variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)