### PR TITLE
feat: add outline Button variant (v1.1.2)

### DIFF
--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -144,6 +144,21 @@ export const Button = styled("button", {
             boxShadow: "inset 0 0 0 1px $colors$primary8",
           },
       },
+      outline: {
+        border: "1px solid $neutral7",
+        bc: "$neutral4",
+        color: "$neutral12",
+        "&:hover": { bc: "$neutral5" },
+        "&:active": { bc: "$neutral6" },
+        "&:disabled": {
+          opacity: 0.5,
+        },
+        '&[data-radix-popover-trigger][data-state="open"], &[data-radix-dropdown-menu-trigger][data-state="open"]':
+          {
+            bc: "$neutral4",
+            boxShadow: "inset 0 0 0 1px $colors$primary8",
+          },
+      },
       ...colorVariants,
     },
     ghost: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livepeer/design-system",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/index.es.js",


### PR DESCRIPTION
## Summary

Adds a new shadcn-aligned `outline` Button variant that restores the pre-#136 subdued styling (grey border, `\$neutral4` bg, `\$neutral12` text). **Purely additive** — no existing variants change behavior.

Supersedes #155 (which took the wrong approach of mutating the existing `neutral` variant).

## Why

PR #136 (shipped in v1.1.1) changed the default `neutral` Button variant from a subdued grey-bordered style to a high-contrast solid fill. Consumers who preferred the subdued look (the Livepeer Explorer, pinned to v1.1.0) lost access to that style without an opt-out.

This PR gives them a named variant: `<Button variant="outline">...</Button>`. The name follows shadcn/ui convention, which lines up with the v2.0 Tailwind + CVA migration's variant vocabulary (\`default\` / \`outline\` / \`secondary\` / \`ghost\` / \`destructive\`). No rename churn when v2.0 lands.

## Migration path

**Consumers currently on v1.1.1** — no change, their default-variant buttons keep the high-contrast styling.

**Consumers currently on v1.1.0 who want to preserve their styling** — bump to v1.1.2 and add an explicit variant:

\`\`\`diff
- <Button>Create Poll</Button>
+ <Button variant="outline">Create Poll</Button>
\`\`\`

This is opt-in, so consumers can migrate button-by-button rather than in one big sweep.

## What changed

- **components/Button.tsx** — new \`outline\` variant added after \`neutral\`, before \`...colorVariants\`. Styling cloned exactly from pre-#136 \`neutral\` definition.
- **package.json** — version \`1.1.0\` → \`1.1.2\` (1.1.1 was the last published version).

## Not in scope

- No changes to \`neutral\`, \`primary\`, \`ghost\`, compound variants, or color variants
- No token renames (\`\$primary\` / \`\$background\` semantic tokens from #136 stay as-is — renaming those is queued for v2.0 per #156)
- No new variants beyond \`outline\`

## Test plan

- [ ] \`yarn ds:build\` succeeds
- [ ] Docs site renders \`<Button variant="outline">\` with grey border + \`\$neutral4\` bg
- [ ] yalc-link v1.1.2 into Explorer, update a representative Button call, verify visual matches current production
- [ ] Verify no regressions to existing variants (neutral stays high-contrast, primary stays solid green, etc.)

## Follow-up work (not this PR)

- Publish v1.1.2 to npm
- Open Explorer PR: bump to v1.1.2 + add \`variant="outline"\` to Button call sites that should keep the subdued look

Refs #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)