### PR TITLE
chore: gitignore .yalc/ and yalc.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 /.pnp
 .pnp.js
 .yarn/cache/
+.yalc/
+yalc.lock
 
 # testing
 /coverage


### PR DESCRIPTION
## Summary

- Adds `.yalc/` and `yalc.lock` to `.gitignore`
- Prevents yalc artifacts from being accidentally committed by developers following the [README yalc workflow](https://github.com/livepeer/design-system#local-consumer-testing-with-yalc)

Both files are per-developer local state (analogous to `node_modules/`) and should never be checked in. The canonical dependency state lives in `package.json` + lockfile.

Refs #156 