### PR TITLE
chore: upgrade React peer dep from 17 to 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "ds:release": "pnpm run ds:build && np"
   },
   "peerDependencies": {
-    "react": "17.0.1",
-    "react-dom": "17.0.1"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "dependencies": {
     "@radix-ui/colors": "0.1.8",


### PR DESCRIPTION
## Summary

Widens `peerDependencies` from pinned `react`/`react-dom` `17.0.1` to `^18.0.0`. The old pin was out of date — Explorer already runs React 19.

One-line change in `package.json`, no source code changes. Build verified.

Refs #156