### PR TITLE
chore: add Tailwind v4 + CVA bridge

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -143,6 +143,10 @@ export { Tooltip } from "./components/Tooltip";
 export { TreeItem } from "./components/TreeItem";
 export { VerifiedBadge } from "./components/VerifiedBadge";
 
+// Tailwind utilities
+export { cn } from "./lib/cn";
+export { cva, type VariantProps } from "class-variance-authority";
+
 // Stitches
 export {
   config,

--- a/lib/cn.ts
+++ b/lib/cn.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/package.json
+++ b/package.json
@@ -53,10 +53,13 @@
     "@radix-ui/react-tooltip": "1.0.6",
     "@radix-ui/react-use-layout-effect": "1.0.1",
     "@stitches/react": "^1.2.8",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
     "lodash.merge": "^4.6.2",
     "lodash.omit": "^4.5.0",
     "next-themes": "^0.2.0",
     "react-transition-group": "4.4.5",
+    "tailwind-merge": "^3.5.0",
     "tslib": "^2.4.0"
   },
   "devDependencies": {
@@ -80,6 +83,7 @@
     "react": "^18.2.0",
     "react-bezier-curve-editor": "^1.1.2",
     "react-dom": "^18.2.0",
+    "tailwindcss": "^4.2.2",
     "tsup": "^8.5.1",
     "typescript": "4.7.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,12 @@ importers:
       '@stitches/react':
         specifier: ^1.2.8
         version: 1.2.8(react@18.3.1)
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       lodash.merge:
         specifier: ^4.6.2
         version: 4.6.2
@@ -116,6 +122,9 @@ importers:
       react-transition-group:
         specifier: 4.4.5
         version: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      tailwind-merge:
+        specifier: ^3.5.0
+        version: 3.5.0
       tslib:
         specifier: ^2.4.0
         version: 2.8.1
@@ -180,6 +189,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.3.1(react@18.3.1)
+      tailwindcss:
+        specifier: ^4.2.2
+        version: 4.2.2
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(postcss@8.4.14)(typescript@4.7.4)
@@ -1868,6 +1880,9 @@ packages:
   ci-info@2.0.0:
     resolution: {integrity: sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==}
 
+  class-variance-authority@0.7.1:
+    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
   classnames@2.5.1:
     resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
 
@@ -1908,6 +1923,10 @@ packages:
 
   clone-response@1.0.3:
     resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   code-point-at@1.1.0:
     resolution: {integrity: sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==}
@@ -4075,6 +4094,12 @@ packages:
     resolution: {integrity: sha512-6tDOXSHiVjuCaasQSWTmHUWn4PuG7qa3+1WT031yTc/swT7+rLiw3GOrFxaH1E3lLP09dH3bVuVDf2gK5rxG3Q==}
     engines: {node: '>=0.10'}
 
+  tailwind-merge@3.5.0:
+    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
+
+  tailwindcss@4.2.2:
+    resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
+
   terminal-link@2.1.1:
     resolution: {integrity: sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==}
     engines: {node: '>=8'}
@@ -5887,6 +5912,10 @@ snapshots:
 
   ci-info@2.0.0: {}
 
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
+
   classnames@2.5.1: {}
 
   clean-stack@2.2.0: {}
@@ -5922,6 +5951,8 @@ snapshots:
   clone-response@1.0.3:
     dependencies:
       mimic-response: 1.0.1
+
+  clsx@2.1.1: {}
 
   code-point-at@1.1.0: {}
 
@@ -6281,7 +6312,7 @@ snapshots:
       eslint: 8.21.0
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.32.0(eslint@8.21.0))(eslint@8.21.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.21.0)(typescript@4.7.4))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.32.0(eslint@8.21.0))(eslint@8.21.0))(eslint@8.21.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.21.0)(typescript@4.7.4))(eslint-import-resolver-typescript@2.7.1)(eslint@8.21.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.21.0)
       eslint-plugin-react: 7.37.5(eslint@8.21.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.21.0)
@@ -6303,7 +6334,7 @@ snapshots:
     dependencies:
       debug: 4.4.3
       eslint: 8.21.0
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.21.0)(typescript@4.7.4))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.32.0(eslint@8.21.0))(eslint@8.21.0))(eslint@8.21.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.21.0)(typescript@4.7.4))(eslint-import-resolver-typescript@2.7.1)(eslint@8.21.0)
       glob: 7.2.3
       is-glob: 4.0.3
       resolve: 1.22.12
@@ -6322,7 +6353,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.21.0)(typescript@4.7.4))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.32.0(eslint@8.21.0))(eslint@8.21.0))(eslint@8.21.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.21.0)(typescript@4.7.4))(eslint-import-resolver-typescript@2.7.1)(eslint@8.21.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -8685,6 +8716,10 @@ snapshots:
   symbol-observable@1.2.0: {}
 
   symbol-observable@3.0.0: {}
+
+  tailwind-merge@3.5.0: {}
+
+  tailwindcss@4.2.2: {}
 
   terminal-link@2.1.1:
     dependencies:

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   clean: true,
   tsconfig: "tsconfig.build.json",
   external: [/^@radix-ui/, /^react/, /^next/, /^@stitches/, /^tslib/],
-  esbuild: {
-    jsx: "transform",
+  esbuildOptions(options) {
+    options.jsx = "transform";
   },
 });


### PR DESCRIPTION
## Summary

Install the tooling for incremental Stitches → Tailwind component migration in v2.0. No existing components are changed.

## What was added

| Package | Type | Purpose |
|---|---|---|
| `class-variance-authority` 0.7.1 | dep | Define component variants as CSS class maps (replaces Stitches' `variants: {}`) |
| `clsx` 2.1.1 | dep | Conditional class name joining |
| `tailwind-merge` 3.5.0 | dep | Deduplicate conflicting Tailwind classes |
| `tailwindcss` 4.2.2 | devDep | Tailwind CSS engine (docs site only, not shipped) |

## New exports

- **`cn(...inputs)`** — standard `clsx` + `twMerge` utility ([lib/cn.ts](lib/cn.ts))
- **`cva`** — re-exported from `class-variance-authority`
- **`VariantProps`** — type helper for extracting variant prop types from CVA definitions

## What this enables

New components can be written with CVA + Tailwind alongside existing Stitches components:

```tsx
import { cn, cva, type VariantProps } from "@livepeer/design-system";

const buttonVariants = cva("inline-flex items-center", {
  variants: {
    size: { "1": "h-5 px-2", "2": "h-6 px-3" },
    variant: { primary: "bg-green-100", neutral: "bg-gray-100" },
  },
});
```

## What this does NOT do

- No existing Stitches component is touched
- No theme token mapping (deferred to v2.0 component migration)
- No CSS output in the published package
- No consumer-visible behavior change

Refs #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)