### PR TITLE
chore: release v1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livepeer/design-system",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
## Summary

Bump version to `1.2.0` — infrastructure modernization release.

## What shipped since v1.1.2

| PR | Change |
|---|---|
| #159 | Gitignore yalc artifacts |
| #160 | Migrate yarn → pnpm + `.nvmrc` + `engines` + `packageManager` |
| #161 | React 17 → 18 peer dep |
| #162 | Swap rollup → tsup (build time 19s → <7s) |
| #163 | Tailwind v4 + CVA bridge (`cn`, `cva`, `VariantProps` exports) |

## What did NOT change

- No existing component behavior changed
- No Stitches removal (deferred to v2.0.0)
- TypeScript stays at 4.7 (blocked by Stitches until v2.0.0)

## Consumer impact

Additive — consumers can upgrade safely. New exports (`cn`, `cva`, `VariantProps`) are available but optional. Existing imports continue to work unchanged.

## After merge

1. Tag `v1.2.0` on main
2. `npm publish --access public` from clean checkout
3. Explorer consumer PR: bump `@livepeer/design-system` to `1.2.0`

Refs #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)